### PR TITLE
Auto-generate Expected Output of Test Cases

### DIFF
--- a/components/Report/StdioTestStageReport.tsx
+++ b/components/Report/StdioTestStageReport.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { useLayoutDispatch, useLayoutState } from "../../contexts/layout";
 import { ReactGhLikeDiff } from "react-gh-like-diff";
 import { TimeoutBanner } from "../TimeoutBanner";
+import { StdioTestReport } from "@/types/stageReport";
 
 const signal = {
   1: "SIGHUP",
@@ -53,7 +54,11 @@ function StdioTestStatus({ allPassed }) {
   );
 }
 
-export function StdioTestStageReportView({ reports }) {
+interface StdioTestStageReportViewProps {
+  reports: StdioTestReport;
+}
+
+export function StdioTestStageReportView({ reports }: StdioTestStageReportViewProps) {
   const dispatch = useLayoutDispatch();
   const [viewingIndex, setViewingIndex] = useState(0);
   const [viewingTestCase, setViewingTestCase] = useState(0);
@@ -115,6 +120,8 @@ export function StdioTestDetailView() {
   const dispatch = useLayoutDispatch();
   const { stdioTestCase } = useLayoutState();
   const [viewingMode, setViewingMode] = useState("stdout");
+
+  if (!stdioTestCase) return null;
 
   if (stdioTestCase.visibility === "ALWAYS_HIDDEN") {
     return (

--- a/components/Report/index.tsx
+++ b/components/Report/index.tsx
@@ -13,6 +13,7 @@ import { MakeStageReportView } from "./MakeStageReport";
 import { GTestStageReportView } from "./GTestStageReport";
 import { JUnitStageReportView } from "./JUnitStageReport";
 import { PyTestStageReportView } from "./PyTestStageReport";
+import { transformModularizedStdioTestReports } from "@/utils/reportTransformation";
 
 export function Report({ report }) {
   const dispatch = useLayoutDispatch();
@@ -206,6 +207,17 @@ export function ReportSlideOver() {
                     {data.report.sanitizedReports !== null &&
                       Object.keys(data.report.sanitizedReports).includes("stdioTest") && (
                         <StdioTestStageReportView reports={data.report.sanitizedReports.stdioTest} />
+                      )}
+                    {/* Temporary fix for missing StdioTest report if `experimentalModularize` is set to true */}
+                    {data.report.sanitizedReports !== null &&
+                      "run" in data.report.sanitizedReports &&
+                      "diff" in data.report.sanitizedReports && (
+                        <StdioTestStageReportView
+                          reports={transformModularizedStdioTestReports(
+                            data.report.sanitizedReports.run,
+                            data.report.sanitizedReports.diff,
+                          )}
+                        />
                       )}
                   </div>
                   <div className="space-y-2">

--- a/contexts/layout.tsx
+++ b/contexts/layout.tsx
@@ -1,3 +1,4 @@
+import { StdioTestCaseReport } from "@/types/stageReport";
 import React, { useContext, useReducer, useEffect } from "react";
 // import { getMessaging, onMessage } from "firebase/messaging";
 // import { firebaseCloudMessaging } from "../lib/webpush";
@@ -19,7 +20,7 @@ interface LayoutState {
   showSlideOver: boolean;
   showNotification: boolean;
   notification?: any;
-  stdioTestCase?: any;
+  stdioTestCase?: StdioTestCaseReport;
   cache: any;
   reportId?: string;
   valgrindTestCase?: any;

--- a/types/stageReport.ts
+++ b/types/stageReport.ts
@@ -1,0 +1,76 @@
+/**
+ * @file Types for sanitized stage reports.
+ */
+
+/** Type of each element in {@link DiffReport}. */
+export type DiffItemReport = {
+  exitCode: number;
+  expect: string[];
+  hasTimedOut: boolean;
+  id: number;
+  isCorrect: boolean;
+  isSuccess: boolean;
+  score: {
+    score: number;
+    total: number;
+  };
+  stderr: string[];
+  stdout: string[];
+  visibility: string;
+};
+
+/**
+ * Report of the `Diff` stage.
+ *
+ * This stage is part of the `StdioTest` experimental modularization feature.
+ */
+export type DiffReport = DiffItemReport[];
+
+/** Type of each element in {@link RunReport}. */
+export type RunItemReport = {
+  args: string;
+  exitCode: number;
+  file: string;
+  hasTimedOut: boolean;
+  id: number;
+  isCorrect: boolean;
+  isSuccess: boolean;
+  stderr: string[];
+  stdin: string[];
+  stdout: string[];
+  visibility: string;
+};
+
+/**
+ * Report of the `Run` stage.
+ *
+ * This stage is part of the `StdioTest` experimental modularization feature.
+ */
+export type RunReport = RunItemReport[];
+
+/** Report of every `StdioTest` test case.  */
+export type StdioTestCaseReport = {
+  args: string;
+  diff: string[];
+  diffExitCode: number;
+  diffStderr: string[];
+  exeExitCode: number;
+  exitCode: number;
+  expect: string[];
+  file: string;
+  hasTimedOut: boolean;
+  id: number;
+  isCorrect: boolean;
+  isSuccess: boolean;
+  score: {
+    score: number;
+    total: number;
+  };
+  stderr: string[];
+  stdin: string[];
+  stdout: string[];
+  visibility: string;
+};
+
+/** Report of `StdioTest` without experimental modularization. */
+export type StdioTestReport = StdioTestCaseReport[];

--- a/utils/reportTransformation.ts
+++ b/utils/reportTransformation.ts
@@ -1,0 +1,51 @@
+/**
+ * @file Utilities for transforming stage reports.
+ */
+
+import { DiffReport, RunReport, StdioTestCaseReport, StdioTestReport } from "@/types/stageReport";
+
+/**
+ * Combines reports from the `Run` and `Diff` stages into a `StdioTest` stage report.
+ *
+ * If the `experimentalModularize` flag is on in `StdioTest`'s configuration, this stage will be modularized into
+ * multiple `Run` and `Diff` stages. However, the Grader currently outputs stage reports for `Run` and `Diff` stages
+ * instead of a single `StdioTest` stage report. Hence, this function intends to merge the `Run` and `Diff` stage reports
+ * into a single `StdioTest` stage report.
+ *
+ * The Grader is still investigating how to merge `Run` and `Diff` reports into a single `StdioTest` report. Once the Grader
+ * has implemented the stage report merging, this function is no longer necessary.
+ *
+ * @param runReport Report of the `Run` stage.
+ * @param diffReport Report of the `Diff` stage.
+ * @returns Report of a `StdioTest` stage, as if the `experimentalModularize` flag is off.
+ */
+export function transformModularizedStdioTestReports(runReport: RunReport, diffReport: DiffReport): StdioTestReport {
+  const output: StdioTestReport = [];
+
+  for (let i = 0; i < runReport.length; i++) {
+    const runReportItem = runReport[i];
+    const diffReportItem = diffReport[i];
+
+    output.push({
+      args: runReportItem.args,
+      diff: diffReportItem.stdout,
+      diffExitCode: diffReportItem.exitCode,
+      diffStderr: diffReportItem.stderr,
+      exeExitCode: runReportItem.exitCode,
+      exitCode: [diffReportItem.exitCode, runReportItem.exitCode].find((code) => code !== 0) ?? 0,
+      expect: diffReportItem.expect,
+      file: runReportItem.file,
+      hasTimedOut: runReportItem.hasTimedOut || diffReportItem.hasTimedOut,
+      id: runReportItem.id,
+      isCorrect: runReportItem.isCorrect && diffReportItem.isCorrect,
+      isSuccess: runReportItem.isSuccess && diffReportItem.isSuccess,
+      score: diffReportItem.score,
+      stderr: runReportItem.stderr,
+      stdin: runReportItem.stdin,
+      stdout: runReportItem.stdout,
+      visibility: runReportItem.visibility,
+    });
+  }
+
+  return output;
+}

--- a/utils/reportTransformation.ts
+++ b/utils/reportTransformation.ts
@@ -2,7 +2,7 @@
  * @file Utilities for transforming stage reports.
  */
 
-import { DiffReport, RunReport, StdioTestCaseReport, StdioTestReport } from "@/types/stageReport";
+import { DiffReport, RunReport, StdioTestReport } from "@/types/stageReport";
 
 /**
  * Combines reports from the `Run` and `Diff` stages into a `StdioTest` stage report.


### PR DESCRIPTION
# :warning: Dependencies

Do NOT merge this PR to `main` blindly! This PR depends on multiple features in other repos. Please deploy these changes **in the given order**:

1. [Grader](https://gitlab.com/zinc-stack/grader/) - Support of the "Auto-generate expected output of test cases" feature in the `StdioTest` stage.
   - i.e., `temp/feature/autogenerate-testcase` is merged to `stable` branch
2. Webhook
   a. [Skip grade immediately if submission is already extracted](https://github.com/ZINC-FYP-2022-23/webhook/commit/f454ab92ba144792d62b9c2de922724992d8889c)
   b. [New `/decompression` hook to trigger decompression manually](https://github.com/ZINC-FYP-2022-23/webhook/commit/2a83b9734805e3d1a9e76732260a7abd26a3606d)
3. **Merge this PR to `student-ui`'s `main`**
4. [Console - Auto-generate Expected Output of Test Cases](https://github.com/ZINC-FYP-2022-23/console/pull/45) 
5. Hasura Server - [Remove `Decompression` event trigger in `submissions` table](https://github.com/ZINC-FYP-2022-23/hasura-server/pull/1)

The motivation for Steps 2 and 5 is [explained here](https://github.com/ZINC-FYP-2022-23/hasura-server/pull/1#issue-1611038391).

# Description

This PR adds support for the "auto-generate expected output of test cases" feature in the `StdioTest` stage:

- Fix the "Standard I/O Test" being missing in the student submission's grade report if the auto-generate expected output feature is on.
  - If the auto-generate feature is on, the `StdioTest` stage will be modularized into `Run` and `Diff`. Hence, we re-generate the missing `StdioTest` stage report by merging the stage reports of `Run` and `Diff` together.
- Uses the [new `/decompression` webhook](https://github.com/ZINC-FYP-2022-23/webhook/commit/2a83b9734805e3d1a9e76732260a7abd26a3606d) to trigger decompression and push a grading task to Redis (if grade immediately).
  - The motivation behind using the new webhook is [explained here](https://github.com/ZINC-FYP-2022-23/hasura-server/pull/1#issue-1611038391).